### PR TITLE
🎨 Palette: Add delete confirmation and improve accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Destructive Action Safety & Detail Accessibility]
+**Learning:** Found that core destructive actions like deleting a game from the detail view lacked a confirmation step, creating a high risk of accidental data loss. Additionally, several icon-only buttons and form controls lacked basic ARIA labels and proper label associations, hindering screen reader support.
+**Action:** Implement custom confirmation modals with loading states for all destructive actions. Ensure icon-only buttons have `aria-label` matching their `title`. Use unique, entity-specific IDs (e.g., `selector-${id}`) for form controls to ensure robust accessibility associations.

--- a/src/components/Library/GameDetail.tsx
+++ b/src/components/Library/GameDetail.tsx
@@ -32,6 +32,8 @@ export function GameDetail({ gameId, onBack, onFilter }: GameDetailProps) {
   const [game, setGame] = useState<Game | null>(null);
   const [loading, setLoading] = useState(true);
   const [notesValue, setNotesValue] = useState("");
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   useEffect(() => { loadGame(); }, [gameId]);
 
@@ -64,7 +66,15 @@ export function GameDetail({ gameId, onBack, onFilter }: GameDetailProps) {
     setGame({ ...game, notes: notesValue });
   };
 
-  const handleDelete = async () => { if (await deleteGame(game.id)) onBack(); };
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    if (await deleteGame(game.id)) {
+      onBack();
+    } else {
+      setIsDeleting(false);
+      setShowDeleteConfirm(false);
+    }
+  };
 
   const handlePlayTimeChange = async (hours: number) => {
     if (await updatePlayTime(game.id, hours)) {
@@ -234,12 +244,58 @@ export function GameDetail({ gameId, onBack, onFilter }: GameDetailProps) {
           {t('added')}: {formatDate(game.created_at)} · {t('updated')}: {formatDate(game.updated_at)}
         </div>
         <div className="pt-4">
-          <button type="button" onClick={handleDelete}
+          <button type="button" onClick={() => setShowDeleteConfirm(true)}
             className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors">
             {t('deleteGame')}
           </button>
         </div>
       </div>
+
+      {/* Delete Confirmation Modal */}
+      {showDeleteConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/80 backdrop-blur-sm">
+          <div className="bg-gray-900 rounded-xl border border-red-600/60 max-w-md w-full shadow-2xl">
+            <div className="p-6 border-b border-gray-800">
+              <div className="flex items-center gap-3 mb-2">
+                <div className="w-10 h-10 bg-red-600/20 rounded-full flex items-center justify-center">
+                  <span className="text-lg" aria-hidden="true">🗑</span>
+                </div>
+                <h2 className="text-lg font-bold text-white">{t('deleteGame')}</h2>
+              </div>
+              <p className="theme-text-secondary text-sm">
+                {t('confirmDelete')}
+              </p>
+              <p className="mt-2 text-indigo-400 font-semibold">{game.display_name}</p>
+            </div>
+
+            <div className="p-6 border-t border-gray-800 flex gap-3">
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(false)}
+                disabled={isDeleting}
+                className="flex-1 px-4 py-3 bg-gray-700 text-white rounded-lg hover:bg-gray-600 disabled:opacity-50 transition-colors"
+              >
+                {t('cancel')}
+              </button>
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={isDeleting}
+                className="flex-1 px-4 py-3 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:bg-red-900/50 disabled:cursor-not-allowed transition-colors font-medium"
+              >
+                {isDeleting ? (
+                  <span className="flex items-center justify-center gap-2">
+                    <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                    {t('loading')}
+                  </span>
+                ) : (
+                  t('deleteGame')
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/Library/GameDetailHeader.tsx
+++ b/src/components/Library/GameDetailHeader.tsx
@@ -148,6 +148,7 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
               onClick={(e) => { e.stopPropagation(); onFavoriteToggle(); }}
               className="absolute -top-2 -right-2 w-10 h-10 flex items-center justify-center text-3xl transition-transform hover:scale-110"
               title={game.is_favorite ? t('removeFromFavorites') : t('addToFavorites')}
+              aria-label={game.is_favorite ? t('removeFromFavorites') : t('addToFavorites')}
             >
               {game.is_favorite ? (
                 <span className="text-yellow-400 drop-shadow-lg">★</span>
@@ -161,10 +162,11 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
         {/* Platform Selector */}
         {onPlatformChange && (
           <div>
-            <label className="block text-xs font-medium theme-text-secondary mb-1">
+            <label htmlFor={`platform-selector-${game.id}`} className="block text-xs font-medium theme-text-secondary mb-1">
               {t('platforms') || 'Plateformes'}
             </label>
             <select
+              id={`platform-selector-${game.id}`}
               value={game.platform || ''}
               onChange={handlePlatformSelect}
               className="w-full px-2 py-1.5 text-sm theme-bg-tertiary theme-border border rounded-lg theme-text-primary focus:ring-2 focus:ring-indigo-500"

--- a/src/components/Library/GameScreenshotsCarousel.tsx
+++ b/src/components/Library/GameScreenshotsCarousel.tsx
@@ -20,7 +20,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
   const [igdbScreenshots, setIgdbScreenshots] = useState<string[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [hasIgdbId, setHasIgdbId] = useState(false);
 
   useEffect(() => {
     const loadScreenshots = async () => {
@@ -29,7 +28,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
         // Load game data to check IGDB ID
         try {
           const game = await invoke<{ igdb_id: number | null }>("get_game_by_id", { id: gameId });
-          setHasIgdbId(!!game?.igdb_id);
           
           // Load IGDB screenshots if available
           if (game?.igdb_id) {


### PR DESCRIPTION
I have implemented a set of micro-UX and accessibility improvements to the Pascal Game Manager.

### 💡 What: The UX enhancement added
- **Confirmation Modal**: Clicking "Delete Game" in the game detail view now opens a confirmation modal instead of deleting the game immediately.
- **Loading Feedback**: The delete button now displays a spinner and "Loading..." text during the deletion process.
- **Accessibility Fixes**:
    - Added `aria-label` to the favorite button (previously icon-only).
    - Added proper `htmlFor` and `id` associations for the platform selector, using unique IDs suffixed with the game ID.
    - Marked decorative emojis in the modal with `aria-hidden="true"`.
- **Cleanup**: Removed an unused state variable (`hasIgdbId`) in `GameScreenshotsCarousel.tsx` that was causing build failures.

### 🎯 Why: The user problem it solves
Destructive actions without confirmation are a major UX friction point and can lead to accidental data loss. Additionally, the lack of ARIA labels and proper form associations made the application less accessible for screen reader users.

### ♿ Accessibility: Any a11y improvements made
- Screen readers now announce the purpose of the favorite button.
- The platform selector label is now correctly linked to the dropdown, improving form navigation.
- Decorative elements are hidden from screen readers to reduce noise.

I verified these changes by running the development server and using a Playwright script to capture screenshots of the new modal and verify ARIA attributes in the DOM.

---
*PR created automatically by Jules for task [4783615532652663034](https://jules.google.com/task/4783615532652663034) started by @Gamepulse*