### PR TITLE
🎨 Palette: Add confirmation for game deletion

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2025-05-15 - [Destructive Action Confirmation]
+**Learning:** All destructive actions (like game deletion) must have a confirmation step. The app uses `window.confirm` with `useI18n` keys for this.
+**Action:** Always wrap delete/reset logic in a confirmation check using existing or new translation keys.
+
+## 2025-05-15 - [Build Constraint: Unused Variables]
+**Learning:** The project's production build (`pnpm build`) includes strict TypeScript linting; unused variables or state declarations will cause build failures.
+**Action:** Ensure all new state or variables introduced for UX features (like loading states or modal visibility) are used, or removed if they become redundant.

--- a/src/components/Library/GameDetail.tsx
+++ b/src/components/Library/GameDetail.tsx
@@ -64,7 +64,11 @@ export function GameDetail({ gameId, onBack, onFilter }: GameDetailProps) {
     setGame({ ...game, notes: notesValue });
   };
 
-  const handleDelete = async () => { if (await deleteGame(game.id)) onBack(); };
+  const handleDelete = async () => {
+    if (window.confirm(t('confirmDelete'))) {
+      if (await deleteGame(game.id)) onBack();
+    }
+  };
 
   const handlePlayTimeChange = async (hours: number) => {
     if (await updatePlayTime(game.id, hours)) {

--- a/src/components/Library/GameScreenshotsCarousel.tsx
+++ b/src/components/Library/GameScreenshotsCarousel.tsx
@@ -20,7 +20,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
   const [igdbScreenshots, setIgdbScreenshots] = useState<string[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [hasIgdbId, setHasIgdbId] = useState(false);
 
   useEffect(() => {
     const loadScreenshots = async () => {
@@ -29,7 +28,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
         // Load game data to check IGDB ID
         try {
           const game = await invoke<{ igdb_id: number | null }>("get_game_by_id", { id: gameId });
-          setHasIgdbId(!!game?.igdb_id);
           
           // Load IGDB screenshots if available
           if (game?.igdb_id) {


### PR DESCRIPTION
I have implemented a micro-UX improvement by adding a confirmation dialog to the game deletion action. This prevents users from accidentally deleting games from their library, which is a destructive and irreversible action.

I also fixed a build-breaking issue where an unused state variable (`hasIgdbId`) was causing `pnpm build` to fail due to strict TypeScript linting.

**Changes:**
- Modified `src/components/Library/GameDetail.tsx` to use `window.confirm` with the `confirmDelete` translation key.
- Cleaned up `src/components/Library/GameScreenshotsCarousel.tsx` by removing the unused `hasIgdbId` state.
- Verified changes with `pnpm test` and `pnpm build`.
- Updated the Palette journal with critical learnings.

---
*PR created automatically by Jules for task [13219338679236443715](https://jules.google.com/task/13219338679236443715) started by @Gamepulse*