### PR TITLE
🎨 Palette: Accessibility improvements for Game Cards and View Modes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+# 🎨 Palette's Journal - UX & Accessibility Learnings
+
+## 2025-05-14 - [Accessibility] Keyboard Support for Pseudo-Buttons
+**Learning:** Interactive elements using `role="button"` (such as spans or divs for tags or badges) are invisible to keyboard users unless they have `tabIndex={0}` and an explicit `onKeyDown` handler. In this app, many tags and badges were only clickable with a mouse.
+**Action:** Always pair `role="button"` with `tabIndex={0}`, `onKeyDown` (supporting 'Enter' and ' '), and visible focus styles (`focus-visible`).

--- a/src/components/Library/GameCard.tsx
+++ b/src/components/Library/GameCard.tsx
@@ -28,6 +28,14 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
     
     console.log('[GameCard] Rendering tags:', displayedTags.map(t => t.name), 'onFilter exists:', !!onFilter);
     
+    const handleKeyDown = (e: React.KeyboardEvent, type: string, value: string) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        e.stopPropagation();
+        onFilter?.(type, value);
+      }
+    };
+
     return (
       <div className="flex flex-wrap gap-1 mt-2 pointer-events-auto">
         {displayedTags.map((tag) => (
@@ -44,8 +52,10 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
                 console.warn('[GameCard] onFilter is undefined!');
               }
             }}
-            className={`relative z-20 px-2 py-0.5 text-xs rounded-full text-white ${getCategoryColor(tag.category)} hover:opacity-80 hover:scale-110 hover:shadow-md transition-all cursor-pointer select-none border border-transparent hover:border-white/30 pointer-events-auto`}
+            onKeyDown={(e) => handleKeyDown(e, 'tag', tag.name)}
+            className={`relative z-20 px-2 py-0.5 text-xs rounded-full text-white ${getCategoryColor(tag.category)} hover:opacity-80 hover:scale-110 hover:shadow-md transition-all cursor-pointer select-none border border-transparent hover:border-white/30 pointer-events-auto focus-visible:ring-2 focus-visible:ring-indigo-500 outline-none`}
             role="button"
+            tabIndex={0}
           >
             {tag.name}
           </span>
@@ -70,6 +80,14 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
     
     if (allMetadata.length === 0) return null;
     
+    const handleKeyDown = (e: React.KeyboardEvent, type: string, value: string) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        e.stopPropagation();
+        onFilter?.(type, value);
+      }
+    };
+
     return (
       <div className="flex flex-wrap gap-1 mt-1">
         {allMetadata.map((item) => (
@@ -81,8 +99,10 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
               console.log('[GameCard] Metadata tag clicked:', item.type, item.name);
               onFilter?.(item.type, item.name);
             }}
-            className="px-1.5 py-0.5 text-xs rounded bg-gray-700/50 theme-text-muted hover:bg-indigo-600/30 transition-colors cursor-pointer select-none"
+            onKeyDown={(e) => handleKeyDown(e, item.type, item.name)}
+            className="px-1.5 py-0.5 text-xs rounded bg-gray-700/50 theme-text-muted hover:bg-indigo-600/30 transition-colors cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-indigo-500 outline-none"
             role="button"
+            tabIndex={0}
           >
             {item.name}
           </span>
@@ -139,8 +159,16 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
           console.log('[GameCard] Status badge clicked:', completion_status);
           onFilter?.('status', completion_status);
         }}
-        className={`absolute top-2 left-2 px-2 py-1 rounded-full text-xs text-white ${statusColors[completion_status] || 'bg-gray-600'} hover:opacity-80 transition-opacity cursor-pointer select-none`}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            e.stopPropagation();
+            onFilter?.('status', completion_status);
+          }
+        }}
+        className={`absolute top-2 left-2 px-2 py-1 rounded-full text-xs text-white ${statusColors[completion_status] || 'bg-gray-600'} hover:opacity-80 transition-opacity cursor-pointer select-none z-10 focus-visible:ring-2 focus-visible:ring-white outline-none`}
         role="button"
+        tabIndex={0}
       >
         {label}
       </span>

--- a/src/components/Library/GameList.tsx
+++ b/src/components/Library/GameList.tsx
@@ -234,6 +234,7 @@ export function GameList({ onSelectGame, searchQuery, activeFilters: externalFil
               onClick={() => setViewMode("grid")}
               className={`p-1.5 rounded ${viewMode === "grid" ? 'theme-accent text-white' : 'theme-text-secondary hover:theme-text-primary'}`}
               title="Grid view"
+              aria-label="Grid view"
             >
               ▦
             </button>
@@ -241,6 +242,7 @@ export function GameList({ onSelectGame, searchQuery, activeFilters: externalFil
               onClick={() => setViewMode("list")}
               className={`p-1.5 rounded ${viewMode === "list" ? 'theme-accent text-white' : 'theme-text-secondary hover:theme-text-primary'}`}
               title="List view"
+              aria-label="List view"
             >
               ☰
             </button>
@@ -248,6 +250,7 @@ export function GameList({ onSelectGame, searchQuery, activeFilters: externalFil
               onClick={() => setViewMode("compact")}
               className={`p-1.5 rounded ${viewMode === "compact" ? 'theme-accent text-white' : 'theme-text-secondary hover:theme-text-primary'}`}
               title="Compact view"
+              aria-label="Compact view"
             >
               ▪
             </button>

--- a/src/components/Library/GameScreenshotsCarousel.tsx
+++ b/src/components/Library/GameScreenshotsCarousel.tsx
@@ -20,7 +20,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
   const [igdbScreenshots, setIgdbScreenshots] = useState<string[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [hasIgdbId, setHasIgdbId] = useState(false);
 
   useEffect(() => {
     const loadScreenshots = async () => {
@@ -29,7 +28,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
         // Load game data to check IGDB ID
         try {
           const game = await invoke<{ igdb_id: number | null }>("get_game_by_id", { id: gameId });
-          setHasIgdbId(!!game?.igdb_id);
           
           // Load IGDB screenshots if available
           if (game?.igdb_id) {


### PR DESCRIPTION
This PR introduces micro-UX and accessibility improvements to the Pascal Game Manager.

### Key Changes:
- **Keyboard Accessibility**: Elements using `role="button"` (tags, status badges, and metadata) in the `GameCard` component are now focusable (`tabIndex={0}`) and can be triggered via keyboard (`Enter` or `Space`).
- **Visual Focus States**: Added `focus-visible` ring indicators to these newly focusable elements to ensure clear navigation for keyboard users.
- **Screen Reader Support**: Added `aria-label` attributes to the icon-only view mode buttons (Grid, List, Compact) in the main library toolbar.
- **Build Reliability**: Removed an unused `hasIgdbId` state in `GameScreenshotsCarousel.tsx` that was causing production build failures due to strict TypeScript checks.
- **Palette Journal**: Documented the accessibility patterns and requirements in `.Jules/palette.md`.

These small touches ensure the interface is more inclusive and robust.

---
*PR created automatically by Jules for task [3068024106668655705](https://jules.google.com/task/3068024106668655705) started by @Gamepulse*