### PR TITLE
🎨 Palette: Accessibility and Keyboard Navigation Improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Accessibility & Navigation Enhancements]
+**Learning:** Interactive elements implemented as `span` or `div` with `role="button"` frequently lack keyboard support and focus styles in this codebase. Adding `tabIndex={0}`, `onKeyDown` handlers, and `focus-visible` ring styles is essential for a consistent keyboard navigation experience. Additionally, icon-only buttons (like favorites or sidebar items) often lack `aria-label` which is critical for screen readers, even when a `title` is present.
+**Action:** Always check for `role="button"` on non-button elements and ensure they have full keyboard parity. Verify that all icon-only buttons have both `title` (for tooltips) and `aria-label` (for A11y).

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -54,6 +54,8 @@ export function Sidebar({ currentView, onNavigate }: SidebarProps) {
           <button
             key={item.id}
             onClick={() => onNavigate(item.id)}
+            title={getLabel(item.id)}
+            aria-label={getLabel(item.id)}
             className={`w-full flex items-center gap-3 px-4 py-3 transition-all duration-200 overflow-hidden whitespace-nowrap ${
               currentView === item.id
                 ? "theme-bg-tertiary border-l-2 border-indigo-500 text-indigo-500 -translate-y-0.5 shadow-md"

--- a/src/components/Layout/__tests__/SidebarA11y.test.tsx
+++ b/src/components/Layout/__tests__/SidebarA11y.test.tsx
@@ -1,0 +1,27 @@
+
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi } from 'vitest';
+import { Sidebar } from '../Sidebar';
+import { I18nProvider } from '../../../i18n/I18nContext';
+
+describe('Sidebar Accessibility', () => {
+  it('has title and aria-label on navigation items', () => {
+    render(
+      <I18nProvider>
+        <Sidebar currentView="library" onNavigate={() => {}} />
+      </I18nProvider>
+    );
+
+    const buttons = screen.getAllByRole('button');
+
+    // Check navigation buttons (first 5)
+    const navButtons = buttons.filter(b => b.textContent !== '◀' && b.textContent !== '▶');
+
+    navButtons.forEach(button => {
+      expect(button).toHaveAttribute('title');
+      expect(button).toHaveAttribute('aria-label');
+      expect(button.getAttribute('title')).toBe(button.getAttribute('aria-label'));
+    });
+  });
+});

--- a/src/components/Library/GameCard.tsx
+++ b/src/components/Library/GameCard.tsx
@@ -33,6 +33,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
         {displayedTags.map((tag) => (
           <span
             key={tag.id}
+            tabIndex={0}
             onClick={(e) => {
               console.log('[GameCard] Click handler fired for tag:', tag.name);
               e.stopPropagation();
@@ -44,8 +45,16 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
                 console.warn('[GameCard] onFilter is undefined!');
               }
             }}
-            className={`relative z-20 px-2 py-0.5 text-xs rounded-full text-white ${getCategoryColor(tag.category)} hover:opacity-80 hover:scale-110 hover:shadow-md transition-all cursor-pointer select-none border border-transparent hover:border-white/30 pointer-events-auto`}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopPropagation();
+                onFilter?.('tag', tag.name);
+              }
+            }}
+            className={`relative z-20 px-2 py-0.5 text-xs rounded-full text-white ${getCategoryColor(tag.category)} hover:opacity-80 hover:scale-110 hover:shadow-md transition-all cursor-pointer select-none border border-transparent hover:border-white/30 pointer-events-auto focus-visible:ring-2 focus-visible:ring-white`}
             role="button"
+            aria-label={t('filterByTag') + ': ' + tag.name}
           >
             {tag.name}
           </span>
@@ -75,14 +84,23 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
         {allMetadata.map((item) => (
           <span
             key={`${item.type}-${item.id}`}
+            tabIndex={0}
             onClick={(e) => {
               e.stopPropagation();
               e.preventDefault();
               console.log('[GameCard] Metadata tag clicked:', item.type, item.name);
               onFilter?.(item.type, item.name);
             }}
-            className="px-1.5 py-0.5 text-xs rounded bg-gray-700/50 theme-text-muted hover:bg-indigo-600/30 transition-colors cursor-pointer select-none"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopPropagation();
+                onFilter?.(item.type, item.name);
+              }
+            }}
+            className="px-1.5 py-0.5 text-xs rounded bg-gray-700/50 theme-text-muted hover:bg-indigo-600/30 transition-colors cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-indigo-500"
             role="button"
+            aria-label={`${t('filterBy') || 'Filter by'} ${item.type}: ${item.name}`}
           >
             {item.name}
           </span>
@@ -133,14 +151,23 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
     
     return (
       <span
+        tabIndex={0}
         onClick={(e) => {
           e.stopPropagation();
           e.preventDefault();
           console.log('[GameCard] Status badge clicked:', completion_status);
           onFilter?.('status', completion_status);
         }}
-        className={`absolute top-2 left-2 px-2 py-1 rounded-full text-xs text-white ${statusColors[completion_status] || 'bg-gray-600'} hover:opacity-80 transition-opacity cursor-pointer select-none`}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            e.stopPropagation();
+            onFilter?.('status', completion_status);
+          }
+        }}
+        className={`absolute top-2 left-2 px-2 py-1 rounded-full text-xs text-white ${statusColors[completion_status] || 'bg-gray-600'} hover:opacity-80 transition-opacity cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-white z-20`}
         role="button"
+        aria-label={`${t('filterBy') || 'Filter by'} status: ${label}`}
       >
         {label}
       </span>

--- a/src/components/Library/GameDetailHeader.tsx
+++ b/src/components/Library/GameDetailHeader.tsx
@@ -148,6 +148,7 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
               onClick={(e) => { e.stopPropagation(); onFavoriteToggle(); }}
               className="absolute -top-2 -right-2 w-10 h-10 flex items-center justify-center text-3xl transition-transform hover:scale-110"
               title={game.is_favorite ? t('removeFromFavorites') : t('addToFavorites')}
+              aria-label={game.is_favorite ? t('removeFromFavorites') : t('addToFavorites')}
             >
               {game.is_favorite ? (
                 <span className="text-yellow-400 drop-shadow-lg">★</span>

--- a/src/components/Library/__tests__/GameCardA11y.test.tsx
+++ b/src/components/Library/__tests__/GameCardA11y.test.tsx
@@ -1,0 +1,66 @@
+
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi } from 'vitest';
+import GameCard from '../GameCard';
+import { I18nProvider } from '../../../i18n/I18nContext';
+import type { Game } from '../../../types';
+
+// Mock common modules
+vi.mock('../../utils/formatters', () => ({
+  formatDate: vi.fn((date) => date),
+}));
+
+vi.mock('../../utils/colors', () => ({
+  getCategoryColor: vi.fn(() => 'bg-blue-500'),
+}));
+
+const mockGame: Game = {
+  id: 1,
+  display_name: 'Test Game',
+  folder_name: 'test-game',
+  folder_path: '/path/to/test-game',
+  igdb_id: 123,
+  igdb_slug: 'test-game',
+  personal_rating: 85,
+  igdb_rating: 90,
+  notes: 'Some notes',
+  cover_url: 'https://example.com/cover.jpg',
+  synopsis: 'A test game synopsis',
+  release_date: '2023-01-01',
+  created_at: '2023-01-01T00:00:00Z',
+  updated_at: '2023-01-01T00:00:00Z',
+  tags: [{ id: 1, name: 'Tag1', category: 'custom' }],
+  genres: [{ id: 1, name: 'Action' }],
+  game_modes: [],
+  player_perspectives: [],
+  themes: [],
+  completion_status: 'playing',
+  play_time: 10,
+  is_favorite: true,
+};
+
+describe('GameCard Accessibility', () => {
+  it('has interactive elements with proper accessibility attributes', () => {
+    render(
+      <I18nProvider>
+        <GameCard game={mockGame} onClick={() => {}} viewMode="grid" onFilter={() => {}} />
+      </I18nProvider>
+    );
+
+    // Check tags
+    const tag = screen.getByRole('button', { name: /Tag1/ });
+    expect(tag).toHaveAttribute('tabIndex', '0');
+    expect(tag).toHaveAttribute('aria-label', expect.stringContaining('Tag1'));
+
+    // Check metadata tags (genres)
+    const genre = screen.getByRole('button', { name: /Action/ });
+    expect(genre).toHaveAttribute('tabIndex', '0');
+    expect(genre).toHaveAttribute('aria-label', expect.stringContaining('Action'));
+
+    // Check status badge
+    const status = screen.getByRole('button', { name: /Playing/i });
+    expect(status).toHaveAttribute('tabIndex', '0');
+    expect(status).toHaveAttribute('aria-label', expect.stringContaining('status'));
+  });
+});


### PR DESCRIPTION
This PR implements several micro-UX and accessibility improvements:

1. **Keyboard Navigation**: In the Library grid, tags and status badges are now keyboard-accessible. Users can tab to them and press Enter or Space to filter the library. Focus rings have been added to make the active element clear.
2. **Screen Reader Support**: ARIA labels have been added to several icon-only or custom interactive elements, including the favorite toggle and sidebar navigation items.
3. **Discoverability**: Sidebar items now have tooltips (title attribute) that appear on hover, which is especially helpful when the sidebar is collapsed and only icons are visible.

New tests were added to ensure these accessibility features remain in place.

---
*PR created automatically by Jules for task [12117199846145639958](https://jules.google.com/task/12117199846145639958) started by @Gamepulse*