### PR TITLE
🎨 Palette: Improve GameDetail accessibility and rating UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Accessible Card Pattern with Nested Interactivity]
+**Learning:** When building complex card components that are themselves interactive (like `GameCard`), adding `role="button"` to the entire container while also containing internal `<button>` elements (e.g., for tags or status badges) creates a nested interactivity anti-pattern. This confuses screen readers and violates ARIA specifications.
+**Action:** Avoid nesting focusable elements within an element with `role="button"`. Instead, use a "stretched link" approach for the card's primary action or keep the container purely stylistic while providing distinct, non-nested buttons for internal actions.

--- a/src/components/Library/GameDetailHeader.tsx
+++ b/src/components/Library/GameDetailHeader.tsx
@@ -132,7 +132,7 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
                 alt={game.display_name} 
                 className="w-full rounded-lg" 
               />
-              <div className="svg-text-mask">
+              <div className="svg-text-mask" aria-hidden="true">
                 <span className="text-4xl font-black text-white drop-shadow-lg" style={{textShadow: '0 2px 8px rgba(0,0,0,0.4)'}}>PPGM</span>
               </div>
             </div>
@@ -146,13 +146,14 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
             <button
               type="button"
               onClick={(e) => { e.stopPropagation(); onFavoriteToggle(); }}
-              className="absolute -top-2 -right-2 w-10 h-10 flex items-center justify-center text-3xl transition-transform hover:scale-110"
+              className="absolute -top-2 -right-2 w-10 h-10 flex items-center justify-center text-3xl transition-transform hover:scale-110 focus-visible:ring-2 ring-[var(--color-accent)] ring-offset-2 ring-offset-gray-900 rounded-full outline-none"
               title={game.is_favorite ? t('removeFromFavorites') : t('addToFavorites')}
+              aria-label={game.is_favorite ? t('removeFromFavorites') : t('addToFavorites')}
             >
               {game.is_favorite ? (
-                <span className="text-yellow-400 drop-shadow-lg">★</span>
+                <span className="text-yellow-400 drop-shadow-lg" aria-hidden="true">★</span>
               ) : (
-                <span className="text-gray-400 hover:text-yellow-300">☆</span>
+                <span className="text-gray-400 hover:text-yellow-300" aria-hidden="true">☆</span>
               )}
             </button>
           )}
@@ -233,21 +234,23 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
         {/* IGDB Page button prominently displayed */}
         {game.igdb_id && (
           <button type="button" onClick={handleOpenIgdb}
-            className="text-blue-400 hover:text-blue-300 text-sm px-3 py-1.5 bg-blue-900/40 rounded-lg hover:bg-blue-900/60 transition-colors inline-flex items-center gap-1">
-            🌐 {t('igdbPage')} ↗
+            className="text-blue-400 hover:text-blue-300 text-sm px-3 py-1.5 bg-blue-900/40 rounded-lg hover:bg-blue-900/60 transition-colors inline-flex items-center gap-1 focus-visible:ring-2 ring-[var(--color-accent)] outline-none">
+            <span aria-hidden="true">🌐</span> {t('igdbPage')} ↗
           </button>
         )}
 
         {/* Folder path */}
-        <p 
-          className="theme-text-muted text-sm font-mono cursor-pointer hover:text-blue-400 hover:underline transition-colors flex items-center gap-1"
+        <button
+          type="button"
+          className="w-full theme-text-muted text-sm font-mono cursor-pointer hover:text-blue-400 hover:underline transition-colors flex items-center gap-1 focus-visible:ring-2 ring-[var(--color-accent)] outline-none rounded text-left"
           onClick={handleOpenFolder}
           title={t('openFolder') || "Click to open folder"}
+          aria-label={(t('openFolder') || "Open folder") + ": " + game.folder_path}
         >
-          <span>📁</span>
+          <span aria-hidden="true">📁</span>
           <span className="truncate">{game.folder_path}</span>
-          <span className="text-xs opacity-50">↗</span>
-        </p>
+          <span className="text-xs opacity-50" aria-hidden="true">↗</span>
+        </button>
 
         {/* Status badges */}
         <div className="flex items-center gap-2 flex-wrap">
@@ -275,9 +278,11 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
             <span className="theme-text-muted text-sm">{t('genres')}:</span>
             {game.genres.map((genre) => (
               <button
+                type="button"
                 key={genre.id}
                 onClick={() => onFilter?.('genre', genre.name)}
-                className="px-2 py-0.5 text-xs rounded-full text-white bg-blue-600 hover:bg-blue-500 transition-opacity cursor-pointer"
+                className="px-2 py-0.5 text-xs rounded-full text-white bg-blue-600 hover:bg-blue-500 transition-opacity cursor-pointer focus-visible:ring-2 ring-offset-1 ring-[var(--color-accent)] outline-none"
+                aria-label={`${t('genre')}: ${genre.name}`}
               >
                 {genre.name}
               </button>
@@ -291,9 +296,11 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
             <span className="theme-text-muted text-sm">{t('gameModes')}:</span>
             {game.game_modes.map((mode) => (
               <button
+                type="button"
                 key={mode.id}
                 onClick={() => onFilter?.('mode', mode.name)}
-                className="px-2 py-0.5 text-xs rounded-full text-white bg-purple-600 hover:bg-purple-500 transition-opacity cursor-pointer"
+                className="px-2 py-0.5 text-xs rounded-full text-white bg-purple-600 hover:bg-purple-500 transition-opacity cursor-pointer focus-visible:ring-2 ring-offset-1 ring-[var(--color-accent)] outline-none"
+                aria-label={`${t('gameMode')}: ${mode.name}`}
               >
                 {mode.name}
               </button>
@@ -307,9 +314,11 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
             <span className="theme-text-muted text-sm">{t('perspective')}:</span>
             {game.player_perspectives.map((persp) => (
               <button
+                type="button"
                 key={persp.id}
                 onClick={() => onFilter?.('perspective', persp.name)}
-                className="px-2 py-0.5 text-xs rounded-full text-white bg-green-600 hover:bg-green-500 transition-opacity cursor-pointer"
+                className="px-2 py-0.5 text-xs rounded-full text-white bg-green-600 hover:bg-green-500 transition-opacity cursor-pointer focus-visible:ring-2 ring-offset-1 ring-[var(--color-accent)] outline-none"
+                aria-label={`${t('perspective')}: ${persp.name}`}
               >
                 {persp.name}
               </button>
@@ -323,9 +332,11 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
             <span className="theme-text-muted text-sm">{t('themes')}:</span>
             {game.themes.map((theme) => (
               <button
+                type="button"
                 key={theme.id}
                 onClick={() => onFilter?.('theme', theme.name)}
-                className="px-2 py-0.5 text-xs rounded-full text-white bg-orange-600 hover:bg-orange-500 transition-opacity cursor-pointer"
+                className="px-2 py-0.5 text-xs rounded-full text-white bg-orange-600 hover:bg-orange-500 transition-opacity cursor-pointer focus-visible:ring-2 ring-offset-1 ring-[var(--color-accent)] outline-none"
+                aria-label={`${t('theme')}: ${theme.name}`}
               >
                 {theme.name}
               </button>
@@ -365,6 +376,17 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
         <div className="space-y-2">
           <div className="flex items-center justify-between">
             <span className="theme-text-muted text-sm">{t('personalRating')} (0-100): <span className="text-purple-500 font-semibold">{game.personal_rating !== null && game.personal_rating !== undefined ? `${game.personal_rating}/100` : '-'}</span></span>
+            {game.personal_rating !== null && game.personal_rating !== undefined && (
+              <button
+                type="button"
+                onClick={() => onRatingChange?.(null)}
+                className="text-xs text-red-400 hover:text-red-300 transition-colors flex items-center gap-1 focus-visible:ring-2 ring-[var(--color-accent)] outline-none rounded px-1"
+                title={t('remove')}
+                aria-label={t('remove')}
+              >
+                <span aria-hidden="true">✕</span> {t('remove')}
+              </button>
+            )}
           </div>
           <div className="flex items-center gap-3">
             <span className="text-xs theme-text-muted">0</span>

--- a/src/components/Library/GameScreenshotsCarousel.tsx
+++ b/src/components/Library/GameScreenshotsCarousel.tsx
@@ -20,7 +20,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
   const [igdbScreenshots, setIgdbScreenshots] = useState<string[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [hasIgdbId, setHasIgdbId] = useState(false);
 
   useEffect(() => {
     const loadScreenshots = async () => {
@@ -29,7 +28,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
         // Load game data to check IGDB ID
         try {
           const game = await invoke<{ igdb_id: number | null }>("get_game_by_id", { id: gameId });
-          setHasIgdbId(!!game?.igdb_id);
           
           // Load IGDB screenshots if available
           if (game?.igdb_id) {


### PR DESCRIPTION
This PR introduces a micro-UX improvement to the game detail page and enhances accessibility across the header.

💡 What:
- Added a "Remove" button next to the personal rating slider. Since native range inputs cannot represent a null/unset state, this provides a clear way for users to remove their rating.
- Replaced the folder path display with a semantic button that is keyboard-accessible and has a descriptive ARIA label.
- Added ARIA labels and focus indicators to genre, mode, theme, and perspective filter buttons.
- Marked decorative branding overlays as `aria-hidden`.
- Fixed a TypeScript build error caused by an unused variable in the screenshots carousel.

🎯 Why:
- Improving the personal rating UX by allowing it to be cleared.
- Ensuring the interface is more accessible for screen reader and keyboard users.
- Maintaining a clean build by removing unused code.

♿ Accessibility:
- Semantic buttons used for all interactive elements.
- Clear `focus-visible` rings added for keyboard navigation.
- Icon-only buttons (favorite, remove rating) have descriptive ARIA labels.
- Decorative elements hidden from screen readers.
- Avoided nested interactivity in cards to comply with ARIA standards.

---
*PR created automatically by Jules for task [9790224091897100206](https://jules.google.com/task/9790224091897100206) started by @Gamepulse*