### PR TITLE
🎨 Palette: Accessible Favorite toggle and Clear Rating button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - [Clear Button for Range Inputs]
+**Learning:** Since native HTML range inputs (`type="range"`) cannot represent a `null` or "unset" state, a separate interactive element is required to allow users to clear numeric values (like personal ratings) once they have been set.
+**Action:** Always provide a 'Clear' or 'Reset' button next to range inputs if the underlying data field is nullable, ensuring it is accessible with proper ARIA labels and focus states.

--- a/src/components/Library/GameDetailHeader.tsx
+++ b/src/components/Library/GameDetailHeader.tsx
@@ -132,7 +132,7 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
                 alt={game.display_name} 
                 className="w-full rounded-lg" 
               />
-              <div className="svg-text-mask">
+              <div className="svg-text-mask" aria-hidden="true">
                 <span className="text-4xl font-black text-white drop-shadow-lg" style={{textShadow: '0 2px 8px rgba(0,0,0,0.4)'}}>PPGM</span>
               </div>
             </div>
@@ -148,11 +148,12 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
               onClick={(e) => { e.stopPropagation(); onFavoriteToggle(); }}
               className="absolute -top-2 -right-2 w-10 h-10 flex items-center justify-center text-3xl transition-transform hover:scale-110"
               title={game.is_favorite ? t('removeFromFavorites') : t('addToFavorites')}
+              aria-label={game.is_favorite ? t('removeFromFavorites') : t('addToFavorites')}
             >
               {game.is_favorite ? (
-                <span className="text-yellow-400 drop-shadow-lg">★</span>
+                <span className="text-yellow-400 drop-shadow-lg" aria-hidden="true">★</span>
               ) : (
-                <span className="text-gray-400 hover:text-yellow-300">☆</span>
+                <span className="text-gray-400 hover:text-yellow-300" aria-hidden="true">☆</span>
               )}
             </button>
           )}
@@ -364,7 +365,20 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
         {/* Personal Rating */}
         <div className="space-y-2">
           <div className="flex items-center justify-between">
-            <span className="theme-text-muted text-sm">{t('personalRating')} (0-100): <span className="text-purple-500 font-semibold">{game.personal_rating !== null && game.personal_rating !== undefined ? `${game.personal_rating}/100` : '-'}</span></span>
+            <div className="flex items-center gap-2">
+              <span className="theme-text-muted text-sm">{t('personalRating')} (0-100): <span className="text-purple-500 font-semibold">{game.personal_rating !== null && game.personal_rating !== undefined ? `${game.personal_rating}/100` : '-'}</span></span>
+              {game.personal_rating !== null && game.personal_rating !== undefined && (
+                <button
+                  type="button"
+                  onClick={() => onRatingChange?.(null)}
+                  className="text-gray-500 hover:text-red-500 transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-indigo-500 rounded px-1"
+                  title={t('clearRating')}
+                  aria-label={t('clearRating')}
+                >
+                  <span aria-hidden="true">✕</span>
+                </button>
+              )}
+            </div>
           </div>
           <div className="flex items-center gap-3">
             <span className="text-xs theme-text-muted">0</span>

--- a/src/components/Library/GameScreenshotsCarousel.tsx
+++ b/src/components/Library/GameScreenshotsCarousel.tsx
@@ -20,7 +20,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
   const [igdbScreenshots, setIgdbScreenshots] = useState<string[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [hasIgdbId, setHasIgdbId] = useState(false);
 
   useEffect(() => {
     const loadScreenshots = async () => {
@@ -29,7 +28,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
         // Load game data to check IGDB ID
         try {
           const game = await invoke<{ igdb_id: number | null }>("get_game_by_id", { id: gameId });
-          setHasIgdbId(!!game?.igdb_id);
           
           // Load IGDB screenshots if available
           if (game?.igdb_id) {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -49,6 +49,7 @@ export const translations = {
     
     // Game Detail
     personalRating: 'Personal Rating',
+    clearRating: 'Clear Rating',
     notes: 'Notes',
     saveNotes: 'Save Notes',
     deleteGame: 'Delete Game',
@@ -435,6 +436,7 @@ export const translations = {
     
     // Game Detail
     personalRating: 'Note personnelle',
+    clearRating: 'Effacer la note',
     notes: 'Notes',
     saveNotes: 'Sauvegarder les notes',
     deleteGame: 'Supprimer le jeu',


### PR DESCRIPTION
This PR introduces micro-UX and accessibility improvements to the game detail view:

- **♿ Accessibility:** Icon-only buttons (Favorite toggle) now have proper \`aria-label\` attributes. Decorative star icons and text masks are now hidden from screen readers to prevent redundant or confusing announcements.
- **✨ UX Enhancement:** Added a "Clear Rating" button next to the personal rating. Since the standard range input doesn't allow unsetting a value, this button provides an intuitive way for users to remove their personal rating.
- **🌐 Localization:** Added the new \`clearRating\` string to the i18n system for both English and French.
- **🛠️ Fixes:** Removed an unused variable in \`GameScreenshotsCarousel.tsx\` that was causing production build failures.

Verified with \`pnpm test\`, \`pnpm build\`, and a Playwright-based visual check.

---
*PR created automatically by Jules for task [7366151441224788551](https://jules.google.com/task/7366151441224788551) started by @Gamepulse*