### PR TITLE
🎨 Palette: Clear Rating UX Improvement & Localization Fix

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2025-05-15 - [UX Pattern: Range Input Null State]
+**Learning:** Native HTML range inputs (`<input type="range">`) cannot represent a `null` or "unset" state as they always default to a value (usually the minimum).
+**Action:** Provide a separate "Clear" or "Reset" button next to numeric range controls to allow users to explicitly unset the value.
+
+## 2025-05-15 - [Accessibility: Icon-only Buttons]
+**Learning:** Icon-only buttons containing text emojis (e.g., ✕) can be confusing for screen readers if the emoji is not hidden and a proper label is not provided.
+**Action:** Wrap text emojis in `<span aria-hidden="true">` and provide both `aria-label` and `title` attributes on the parent button.

--- a/src/components/Library/GameDetailHeader.tsx
+++ b/src/components/Library/GameDetailHeader.tsx
@@ -364,7 +364,20 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
         {/* Personal Rating */}
         <div className="space-y-2">
           <div className="flex items-center justify-between">
-            <span className="theme-text-muted text-sm">{t('personalRating')} (0-100): <span className="text-purple-500 font-semibold">{game.personal_rating !== null && game.personal_rating !== undefined ? `${game.personal_rating}/100` : '-'}</span></span>
+            <div className="flex items-center gap-2">
+              <span className="theme-text-muted text-sm">{t('personalRating')} (0-100): <span className="text-purple-500 font-semibold">{game.personal_rating !== null && game.personal_rating !== undefined ? `${game.personal_rating}/100` : '-'}</span></span>
+              {game.personal_rating !== null && game.personal_rating !== undefined && (
+                <button
+                  type="button"
+                  onClick={() => onRatingChange?.(null)}
+                  className="theme-text-muted hover:text-red-400 transition-colors focus-visible:ring-1 focus-visible:ring-red-400 rounded p-0.5"
+                  aria-label={t('clearRating')}
+                  title={t('clearRating')}
+                >
+                  <span aria-hidden="true">✕</span>
+                </button>
+              )}
+            </div>
           </div>
           <div className="flex items-center gap-3">
             <span className="text-xs theme-text-muted">0</span>

--- a/src/components/Library/GameScreenshotsCarousel.tsx
+++ b/src/components/Library/GameScreenshotsCarousel.tsx
@@ -20,7 +20,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
   const [igdbScreenshots, setIgdbScreenshots] = useState<string[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [hasIgdbId, setHasIgdbId] = useState(false);
 
   useEffect(() => {
     const loadScreenshots = async () => {
@@ -29,7 +28,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
         // Load game data to check IGDB ID
         try {
           const game = await invoke<{ igdb_id: number | null }>("get_game_by_id", { id: gameId });
-          setHasIgdbId(!!game?.igdb_id);
           
           // Load IGDB screenshots if available
           if (game?.igdb_id) {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -49,6 +49,7 @@ export const translations = {
     
     // Game Detail
     personalRating: 'Personal Rating',
+    clearRating: 'Clear Rating',
     notes: 'Notes',
     saveNotes: 'Save Notes',
     deleteGame: 'Delete Game',
@@ -291,7 +292,7 @@ export const translations = {
     playTime: 'Play Time',
     hours: 'hours',
     platform: 'Platform',
-    platforms: 'Plateformes',
+    platforms: 'Platforms',
     selectPlatform: 'Select platform...',
     noPlatform: 'No platform',
     availableOnIGDB: 'Available on',
@@ -435,6 +436,7 @@ export const translations = {
     
     // Game Detail
     personalRating: 'Note personnelle',
+    clearRating: 'Effacer la note',
     notes: 'Notes',
     saveNotes: 'Sauvegarder les notes',
     deleteGame: 'Supprimer le jeu',


### PR DESCRIPTION
This PR implements a micro-UX improvement for the game detail view and fixes a localization typo.

### 💡 What:
1.  **Clear Rating Button**: Added a small ✕ button next to the personal rating value. This allows users to reset their rating to `null`, which was previously impossible once a rating was set because the range slider always has a value.
2.  **Localization Fix**: Corrected the English translation key for `platforms`, which was incorrectly set to the French word "Plateformes".
3.  **Build Fix**: Removed an unused state variable (`hasIgdbId`) in `GameScreenshotsCarousel.tsx` that was causing `pnpm build` to fail.

### 🎯 Why:
- Native range inputs don't support a null state, leading to a poor user experience when someone wants to remove a rating.
- Inconsistent localization (French in the English translation) reduces the professional feel of the app.
- Fixing build errors ensures continuous integration remains green.

### ♿ Accessibility:
- The new "Clear" button uses `aria-label` and `title` for screen readers and tooltips.
- The ✕ icon is wrapped in `<span aria-hidden="true">` to prevent screen readers from reading the literal character incorrectly.
- Focus visible rings are applied to the new interactive element.

### 📸 Before/After:
[Verification screenshots and videos have been generated and reviewed during the verification step.]

---
*PR created automatically by Jules for task [11079253541627504770](https://jules.google.com/task/11079253541627504770) started by @Gamepulse*