### PR TITLE
🎨 Palette: Improve personal rating UX and accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Accessible Personal Ratings]
+**Learning:** Range sliders for 0-100 ratings often lack a way to represent a 'null' or 'unset' state. Providing an explicit "Clear" button with proper ARIA labeling improves both UX and accessibility. Additionally, marking min/max text labels as `aria-hidden` prevents redundant screen reader announcements.
+**Action:** Always provide a way to unset numeric values that use range inputs, and ensure icon-only clear buttons have localized `aria-label` and `title`.

--- a/src/components/Library/GameDetailHeader.tsx
+++ b/src/components/Library/GameDetailHeader.tsx
@@ -365,9 +365,20 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
         <div className="space-y-2">
           <div className="flex items-center justify-between">
             <span className="theme-text-muted text-sm">{t('personalRating')} (0-100): <span className="text-purple-500 font-semibold">{game.personal_rating !== null && game.personal_rating !== undefined ? `${game.personal_rating}/100` : '-'}</span></span>
+            {game.personal_rating !== null && game.personal_rating !== undefined && (
+              <button
+                type="button"
+                onClick={() => onRatingChange?.(null)}
+                className="text-xs text-red-400 hover:text-red-300 transition-colors flex items-center gap-1"
+                aria-label={t('clearRating')}
+                title={t('clearRating')}
+              >
+                ✕
+              </button>
+            )}
           </div>
           <div className="flex items-center gap-3">
-            <span className="text-xs theme-text-muted">0</span>
+            <span className="text-xs theme-text-muted" aria-hidden="true">0</span>
             <input
               type="range"
               min="0"
@@ -375,6 +386,7 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
               step="1"
               value={game.personal_rating || 0}
               onChange={(e) => onRatingChange?.(parseInt(e.target.value) || 0)}
+              aria-label={t('personalRating')}
               className="flex-1 h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer
                 [&::-webkit-slider-thumb]:appearance-none 
                 [&::-webkit-slider-thumb]:w-4 
@@ -390,7 +402,7 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
                 [&::-moz-range-thumb]:cursor-pointer
                 [&::-moz-range-thumb]:border-0"
             />
-            <span className="text-xs theme-text-muted">100</span>
+            <span className="text-xs theme-text-muted" aria-hidden="true">100</span>
           </div>
         </div>
 

--- a/src/components/Library/GameScreenshotsCarousel.tsx
+++ b/src/components/Library/GameScreenshotsCarousel.tsx
@@ -20,7 +20,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
   const [igdbScreenshots, setIgdbScreenshots] = useState<string[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [hasIgdbId, setHasIgdbId] = useState(false);
 
   useEffect(() => {
     const loadScreenshots = async () => {
@@ -29,7 +28,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
         // Load game data to check IGDB ID
         try {
           const game = await invoke<{ igdb_id: number | null }>("get_game_by_id", { id: gameId });
-          setHasIgdbId(!!game?.igdb_id);
           
           // Load IGDB screenshots if available
           if (game?.igdb_id) {

--- a/src/components/common/RatingInput.tsx
+++ b/src/components/common/RatingInput.tsx
@@ -58,9 +58,10 @@ export function RatingInput({ value, onChange, disabled }: RatingInputProps) {
                 : 'bg-gray-800 text-gray-400 hover:bg-gray-700'
               }
             `}
-            aria-label={`Rating ${rating}`}
+            aria-label={`Rate ${rating} out of 10`}
+            aria-pressed={value === rating}
           >
-            {rating}
+            <span aria-hidden="true">{rating}</span>
           </button>
         );
       })}

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -49,6 +49,7 @@ export const translations = {
     
     // Game Detail
     personalRating: 'Personal Rating',
+    clearRating: 'Clear Rating',
     notes: 'Notes',
     saveNotes: 'Save Notes',
     deleteGame: 'Delete Game',
@@ -435,6 +436,7 @@ export const translations = {
     
     // Game Detail
     personalRating: 'Note personnelle',
+    clearRating: 'Effacer la note',
     notes: 'Notes',
     saveNotes: 'Sauvegarder les notes',
     deleteGame: 'Supprimer le jeu',


### PR DESCRIPTION
This PR implements several micro-UX and accessibility improvements focused on the personal rating system:

1.  **Clear Rating Functionality**: Added an '✕' button next to the personal rating in the game detail header. This allows users to completely unset their rating, which was previously impossible with the range slider once a value was set.
2.  **Improved Rating Accessibility**:
    *   Updated the `RatingInput` component (used in other parts of the app) to include `aria-pressed` for the selected rating and more descriptive labels (e.g., "Rate 4 out of 10").
    *   Added `aria-label` to the 0-100 range input in `GameDetailHeader`.
    *   Marked decorative "0" and "100" text labels as `aria-hidden="true"` to reduce screen reader noise.
3.  **Localization**: Added English and French translations for the new "Clear Rating" button.
4.  **Code Cleanup**: Removed an unused `hasIgdbId` state from `GameScreenshotsCarousel` that was causing strict TypeScript build failures.

These changes make the rating system more intuitive to use and fully accessible to screen reader users.

---
*PR created automatically by Jules for task [13499473923930011348](https://jules.google.com/task/13499473923930011348) started by @Gamepulse*