### PR TITLE
🎨 Palette: Improve Personal Rating UX and Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Range Input Null State & Accessibility]
+**Learning:** Native HTML range inputs (`type="range"`) do not support a `null` or "unset" state once a value is interacted with. For features like personal ratings where "no rating" is a valid state, providing a separate "Clear" button is essential for usability. From an accessibility standpoint, range inputs must be explicitly associated with a `<label>` via `id`/`htmlFor`, and any purely decorative boundary markers (like "0" and "100" text) should be marked with `aria-hidden="true"` to avoid redundant screen reader announcements.
+**Action:** When using range sliders for optional numeric values, always include an explicit "Clear" action and verify proper ARIA labeling and marker hiding.

--- a/src/components/Library/GameDetailHeader.tsx
+++ b/src/components/Library/GameDetailHeader.tsx
@@ -364,11 +364,25 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
         {/* Personal Rating */}
         <div className="space-y-2">
           <div className="flex items-center justify-between">
-            <span className="theme-text-muted text-sm">{t('personalRating')} (0-100): <span className="text-purple-500 font-semibold">{game.personal_rating !== null && game.personal_rating !== undefined ? `${game.personal_rating}/100` : '-'}</span></span>
+            <label htmlFor="personal-rating" className="theme-text-muted text-sm cursor-pointer">
+              {t('personalRating')} (0-100): <span className="text-purple-500 font-semibold">{game.personal_rating !== null && game.personal_rating !== undefined ? `${game.personal_rating}/100` : '-'}</span>
+            </label>
+            {game.personal_rating !== null && game.personal_rating !== undefined && onRatingChange && (
+              <button
+                type="button"
+                onClick={() => onRatingChange(null)}
+                className="text-xs theme-text-muted hover:theme-text-primary flex items-center gap-1 transition-colors"
+                title={t('clearRating')}
+                aria-label={t('clearRating')}
+              >
+                <span>✕</span> {t('clearRating')}
+              </button>
+            )}
           </div>
           <div className="flex items-center gap-3">
-            <span className="text-xs theme-text-muted">0</span>
+            <span className="text-xs theme-text-muted" aria-hidden="true">0</span>
             <input
+              id="personal-rating"
               type="range"
               min="0"
               max="100"
@@ -390,7 +404,7 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
                 [&::-moz-range-thumb]:cursor-pointer
                 [&::-moz-range-thumb]:border-0"
             />
-            <span className="text-xs theme-text-muted">100</span>
+            <span className="text-xs theme-text-muted" aria-hidden="true">100</span>
           </div>
         </div>
 

--- a/src/components/Library/GameScreenshotsCarousel.tsx
+++ b/src/components/Library/GameScreenshotsCarousel.tsx
@@ -20,7 +20,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
   const [igdbScreenshots, setIgdbScreenshots] = useState<string[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [hasIgdbId, setHasIgdbId] = useState(false);
 
   useEffect(() => {
     const loadScreenshots = async () => {
@@ -29,7 +28,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
         // Load game data to check IGDB ID
         try {
           const game = await invoke<{ igdb_id: number | null }>("get_game_by_id", { id: gameId });
-          setHasIgdbId(!!game?.igdb_id);
           
           // Load IGDB screenshots if available
           if (game?.igdb_id) {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -49,6 +49,7 @@ export const translations = {
     
     // Game Detail
     personalRating: 'Personal Rating',
+    clearRating: 'Clear Rating',
     notes: 'Notes',
     saveNotes: 'Save Notes',
     deleteGame: 'Delete Game',
@@ -435,6 +436,7 @@ export const translations = {
     
     // Game Detail
     personalRating: 'Note personnelle',
+    clearRating: 'Effacer la note',
     notes: 'Notes',
     saveNotes: 'Sauvegarder les notes',
     deleteGame: 'Supprimer le jeu',


### PR DESCRIPTION
This PR implements a micro-UX improvement for the Personal Rating feature.

### 💡 What:
- Added a "Clear Rating" button (✕) next to the personal rating label in the game detail header.
- Converted the rating display into a semantic `<label>` associated with the range input.
- Marked the "0" and "100" markers as `aria-hidden`.
- Cleaned up an unused state variable in `GameScreenshotsCarousel.tsx` that was causing build failures.

### 🎯 Why:
- Native HTML range inputs cannot represent a `null` state once interacted with. Users needed a way to remove a rating entirely.
- Improved accessibility ensures screen readers correctly identify the rating slider and ignore decorative text.

### ♿ Accessibility:
- Proper label association using `htmlFor`.
- Descriptive `aria-label` and `title` for the new "Clear Rating" button.
- Reduced noise for screen readers by hiding decorative markers.

---
*PR created automatically by Jules for task [16758512822683638821](https://jules.google.com/task/16758512822683638821) started by @Gamepulse*