### PR TITLE
🎨 Palette: Improve rating UX and general accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,9 @@
+## 2025-05-15 - [Accessibility & Rating UX]
+**Learning:** When using `role="button"` on a container (like a Card) that has nested interactive elements, a standard `target.closest('[role="button"]')` check in the `onClick` handler will also match the container itself, blocking navigation.
+**Action:** Use `target.closest('button, a, [role="button"]')` and verify that the result is not `e.currentTarget` to differentiate between a click on the card and a click on a nested control.
+
+**Learning:** Visual labels for range inputs (like '0' and '100' marks) are redundant for screen readers when the input is properly labeled via `htmlFor`.
+**Action:** Wrap such decorative boundary labels in `<span aria-hidden="true">`.
+
+**Learning:** Native HTML range inputs cannot be easily reset to a 'null' or 'unset' state by the user.
+**Action:** Provide a explicit "Clear" or "Reset" button (e.g., a small '✕' button) to allow users to remove a numeric rating.

--- a/src/components/Library/GameCard.tsx
+++ b/src/components/Library/GameCard.tsx
@@ -17,6 +17,15 @@ interface GameCardProps {
 const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, showQuickAssign, onQuickAssign }) => {
   const { t } = useI18n();
   const { display_name, cover_url, personal_rating, igdb_rating, tags, release_date, completion_status, play_time, is_favorite, genres, game_modes, player_perspectives, themes, platform } = game;
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      if (e.target === e.currentTarget) {
+        e.preventDefault();
+        onClick(game.id);
+      }
+    }
+  };
   
   const platformIcon = platform ? (platform.startsWith('ps') ? '🎮' : platform.startsWith('xbox') ? '🎯' : platform.startsWith('nintendo') ? '🕹️' : platform === 'pc' ? '💻' : platform === 'mobile' ? '📱' : '📟') : null;
   
@@ -166,12 +175,17 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
   if (viewMode === "grid") {
     return (
       <div
-        className="theme-card theme-border border rounded-lg overflow-hidden cursor-pointer transition-all duration-300 hover:scale-105 hover:shadow-xl hover:border-gray-600"
+        className="theme-card theme-border border rounded-lg overflow-hidden cursor-pointer transition-all duration-300 hover:scale-105 hover:shadow-xl hover:border-gray-600 focus-within:ring-2 focus-within:ring-indigo-500 outline-none"
+        role="button"
+        tabIndex={0}
+        aria-label={display_name}
+        onKeyDown={handleKeyDown}
         onClick={(e) => {
-          // Don't navigate if clicking on an interactive element
+          // Don't navigate if clicking on an interactive element (excluding the container itself)
           const target = e.target as HTMLElement;
-          if (target.closest('[role="button"]') || target.closest('button') || target.closest('a')) {
-            console.log('[GameCard] Grid click blocked - interactive element');
+          const interactiveChild = target.closest('button, a, [role="button"]');
+          if (interactiveChild && interactiveChild !== e.currentTarget) {
+            console.log('[GameCard] Grid click blocked - interactive child');
             return;
           }
           console.log('[GameCard] Grid click - navigating to game:', game.id);
@@ -190,6 +204,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
             {platformIcon && <span className="text-sm">{platformIcon}</span>}
             {showQuickAssign && (
               <button
+                type="button"
                 onClick={(e) => {
                   e.stopPropagation();
                   e.preventDefault();
@@ -197,6 +212,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
                 }}
                 className="ml-auto text-xs px-2 py-1 bg-orange-500 hover:bg-orange-600 text-white rounded transition-colors"
                 title="Quick assign platform"
+                aria-label={t('quickAdd')}
               >
                 🎮
               </button>
@@ -235,10 +251,15 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
   if (viewMode === "compact") {
     return (
       <div
-        className="theme-card theme-border border rounded-lg overflow-hidden cursor-pointer transition-all duration-200 hover:scale-105 hover:shadow-lg hover:border-gray-600 relative"
+        className="theme-card theme-border border rounded-lg overflow-hidden cursor-pointer transition-all duration-200 hover:scale-105 hover:shadow-lg hover:border-gray-600 relative focus-within:ring-2 focus-within:ring-indigo-500 outline-none"
+        role="button"
+        tabIndex={0}
+        aria-label={display_name}
+        onKeyDown={handleKeyDown}
         onClick={(e) => {
           const target = e.target as HTMLElement;
-          if (target.closest('[role="button"]') || target.closest('button') || target.closest('a')) {
+          const interactiveChild = target.closest('button, a, [role="button"]');
+          if (interactiveChild && interactiveChild !== e.currentTarget) {
             return;
           }
           onClick(game.id);
@@ -291,12 +312,14 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
           {/* Quick assign button - bottom left, above platform icon */}
           {showQuickAssign && (
             <button
+              type="button"
               onClick={(e) => {
                 e.stopPropagation();
                 onQuickAssign?.();
               }}
               className="absolute bottom-1 left-1 w-5 h-5 flex items-center justify-center text-[10px] bg-orange-500 hover:bg-orange-600 text-white rounded transition-colors z-10"
               title="Quick assign platform"
+              aria-label={t('quickAdd')}
             >
               🎮
             </button>
@@ -339,10 +362,15 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
   // List view mode
   return (
     <div
-      className="theme-card theme-border border rounded-lg p-4 flex gap-4 cursor-pointer transition-all duration-300 hover:scale-[1.02] hover:shadow-xl hover:border-gray-600"
+      className="theme-card theme-border border rounded-lg p-4 flex gap-4 cursor-pointer transition-all duration-300 hover:scale-[1.02] hover:shadow-xl hover:border-gray-600 focus-within:ring-2 focus-within:ring-indigo-500 outline-none"
+      role="button"
+      tabIndex={0}
+      aria-label={display_name}
+      onKeyDown={handleKeyDown}
       onClick={(e) => {
         const target = e.target as HTMLElement;
-        if (target.closest('[role="button"]') || target.closest('button') || target.closest('a')) {
+        const interactiveChild = target.closest('button, a, [role="button"]');
+        if (interactiveChild && interactiveChild !== e.currentTarget) {
           return;
         }
         onClick(game.id);
@@ -374,12 +402,14 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
             {platformIcon && <span className="text-lg">{platformIcon}</span>}
             {showQuickAssign && (
               <button
+                type="button"
                 onClick={(e) => {
                   e.stopPropagation();
                   onQuickAssign?.();
                 }}
                 className="ml-2 text-xs px-2 py-1 bg-orange-500 hover:bg-orange-600 text-white rounded transition-colors"
                 title="Quick assign platform"
+                aria-label={t('quickAdd')}
               >
                 🎮
               </button>

--- a/src/components/Library/GameDetailHeader.tsx
+++ b/src/components/Library/GameDetailHeader.tsx
@@ -138,7 +138,7 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
             </div>
           ) : (
             <div className="w-full h-80 bg-gradient-to-br from-indigo-600 to-purple-700 rounded-lg flex items-center justify-center">
-              <span className="text-5xl">🎮</span>
+              <span className="text-5xl" aria-hidden="true">🎮</span>
             </div>
           )}
           {/* Favorite Star - top right corner */}
@@ -148,6 +148,7 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
               onClick={(e) => { e.stopPropagation(); onFavoriteToggle(); }}
               className="absolute -top-2 -right-2 w-10 h-10 flex items-center justify-center text-3xl transition-transform hover:scale-110"
               title={game.is_favorite ? t('removeFromFavorites') : t('addToFavorites')}
+              aria-label={game.is_favorite ? t('removeFromFavorites') : t('addToFavorites')}
             >
               {game.is_favorite ? (
                 <span className="text-yellow-400 drop-shadow-lg">★</span>
@@ -161,10 +162,14 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
         {/* Platform Selector */}
         {onPlatformChange && (
           <div>
-            <label className="block text-xs font-medium theme-text-secondary mb-1">
+            <label
+              htmlFor={`platform-select-${game.id}`}
+              className="block text-xs font-medium theme-text-secondary mb-1"
+            >
               {t('platforms') || 'Plateformes'}
             </label>
             <select
+              id={`platform-select-${game.id}`}
               value={game.platform || ''}
               onChange={handlePlatformSelect}
               className="w-full px-2 py-1.5 text-sm theme-bg-tertiary theme-border border rounded-lg theme-text-primary focus:ring-2 focus:ring-indigo-500"
@@ -234,7 +239,7 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
         {game.igdb_id && (
           <button type="button" onClick={handleOpenIgdb}
             className="text-blue-400 hover:text-blue-300 text-sm px-3 py-1.5 bg-blue-900/40 rounded-lg hover:bg-blue-900/60 transition-colors inline-flex items-center gap-1">
-            🌐 {t('igdbPage')} ↗
+            <span aria-hidden="true">🌐</span> {t('igdbPage')} ↗
           </button>
         )}
 
@@ -244,7 +249,7 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
           onClick={handleOpenFolder}
           title={t('openFolder') || "Click to open folder"}
         >
-          <span>📁</span>
+          <span aria-hidden="true">📁</span>
           <span className="truncate">{game.folder_path}</span>
           <span className="text-xs opacity-50">↗</span>
         </p>
@@ -364,11 +369,28 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
         {/* Personal Rating */}
         <div className="space-y-2">
           <div className="flex items-center justify-between">
-            <span className="theme-text-muted text-sm">{t('personalRating')} (0-100): <span className="text-purple-500 font-semibold">{game.personal_rating !== null && game.personal_rating !== undefined ? `${game.personal_rating}/100` : '-'}</span></span>
+            <label
+              htmlFor={`personal-rating-${game.id}`}
+              className="theme-text-muted text-sm"
+            >
+              {t('personalRating')} (0-100): <span className="text-purple-500 font-semibold">{game.personal_rating !== null && game.personal_rating !== undefined ? `${game.personal_rating}/100` : '-'}</span>
+            </label>
+            {game.personal_rating !== null && game.personal_rating !== undefined && (
+              <button
+                type="button"
+                onClick={() => onRatingChange?.(null)}
+                className="text-xs text-red-400 hover:text-red-300 transition-colors flex items-center gap-1"
+                title={t('clearRating')}
+                aria-label={t('clearRating')}
+              >
+                <span>✕</span> {t('clearAll')}
+              </button>
+            )}
           </div>
           <div className="flex items-center gap-3">
-            <span className="text-xs theme-text-muted">0</span>
+            <span className="text-xs theme-text-muted" aria-hidden="true">0</span>
             <input
+              id={`personal-rating-${game.id}`}
               type="range"
               min="0"
               max="100"
@@ -390,7 +412,7 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
                 [&::-moz-range-thumb]:cursor-pointer
                 [&::-moz-range-thumb]:border-0"
             />
-            <span className="text-xs theme-text-muted">100</span>
+            <span className="text-xs theme-text-muted" aria-hidden="true">100</span>
           </div>
         </div>
 

--- a/src/components/Library/GameScreenshotsCarousel.tsx
+++ b/src/components/Library/GameScreenshotsCarousel.tsx
@@ -20,7 +20,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
   const [igdbScreenshots, setIgdbScreenshots] = useState<string[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [hasIgdbId, setHasIgdbId] = useState(false);
 
   useEffect(() => {
     const loadScreenshots = async () => {
@@ -29,7 +28,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
         // Load game data to check IGDB ID
         try {
           const game = await invoke<{ igdb_id: number | null }>("get_game_by_id", { id: gameId });
-          setHasIgdbId(!!game?.igdb_id);
           
           // Load IGDB screenshots if available
           if (game?.igdb_id) {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -49,6 +49,7 @@ export const translations = {
     
     // Game Detail
     personalRating: 'Personal Rating',
+    clearRating: 'Clear Rating',
     notes: 'Notes',
     saveNotes: 'Save Notes',
     deleteGame: 'Delete Game',
@@ -435,6 +436,7 @@ export const translations = {
     
     // Game Detail
     personalRating: 'Note personnelle',
+    clearRating: 'Effacer la note',
     notes: 'Notes',
     saveNotes: 'Sauvegarder les notes',
     deleteGame: 'Supprimer le jeu',


### PR DESCRIPTION
This PR introduces several micro-UX and accessibility improvements:

1. **Rating UX**: Added a "Clear Rating" button next to the personal rating scale in the game detail view. Since range inputs cannot natively represent a "null" state once changed, this provides a way for users to unset their rating.
2. **Keyboard Accessibility**: `GameCard` components now support full keyboard navigation. They are marked as buttons, can be focused, and triggered via Enter or Space keys.
3. **Semantic HTML**: Associated "Platform" and "Personal Rating" labels with their respective controls using `id` and `htmlFor`.
4. **Screen Reader Optimization**: 
   - Added `aria-label` to the Favorite toggle button and Quick Assign buttons.
   - Marked decorative emojis (📁, 🌐, 🎮) and redundant range bound labels (0, 100) as `aria-hidden="true"`.
5. **Robust Event Handling**: Implemented a check in `GameCard` to differentiate between clicks on the card itself and clicks on nested interactive elements (like tags or buttons) when using the new `role="button"` container.
6. **Build Fix**: Removed an unused `hasIgdbId` state in `GameScreenshotsCarousel.tsx` that was causing production build failures.

All changes are localized in English and French. Verified with `pnpm test`, `pnpm build`, and automated Playwright verification.

---
*PR created automatically by Jules for task [5546363605467897973](https://jules.google.com/task/5546363605467897973) started by @Gamepulse*