### PR TITLE
🎨 Palette: Add Clear Rating button and improve accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Personal Rating UX Improvement]
+**Learning:** Native HTML range inputs cannot represent a `null` state once interacted with. Providing a separate 'Clear' button is essential for allowing users to unset numeric values. Additionally, marking range bounds as `aria-hidden="true"` reduces screen reader noise when the input itself is properly labeled.
+**Action:** Always provide a clear/reset mechanism for optional numeric inputs and ensure proper ARIA labeling for range controls.

--- a/src/components/Library/GameDetailHeader.tsx
+++ b/src/components/Library/GameDetailHeader.tsx
@@ -364,16 +364,29 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
         {/* Personal Rating */}
         <div className="space-y-2">
           <div className="flex items-center justify-between">
-            <span className="theme-text-muted text-sm">{t('personalRating')} (0-100): <span className="text-purple-500 font-semibold">{game.personal_rating !== null && game.personal_rating !== undefined ? `${game.personal_rating}/100` : '-'}</span></span>
+            <span className="theme-text-muted text-sm">
+              {t('personalRating')} (0-100): <span className="text-purple-500 font-semibold">{game.personal_rating !== null && game.personal_rating !== undefined ? `${game.personal_rating}/100` : '-'}</span>
+            </span>
+            {game.personal_rating !== null && game.personal_rating !== undefined && (
+              <button
+                type="button"
+                onClick={() => onRatingChange?.(null)}
+                className="text-xs px-2 py-1 theme-bg-tertiary theme-text-muted rounded hover:theme-text-primary transition-colors focus-visible:ring-2 ring-indigo-500 ring-offset-1 ring-offset-gray-900 outline-none"
+                title={t('clearRating')}
+                aria-label={t('clearRating')}
+              >
+                ✕ {t('clearRating')}
+              </button>
+            )}
           </div>
           <div className="flex items-center gap-3">
-            <span className="text-xs theme-text-muted">0</span>
+            <span className="text-xs theme-text-muted" aria-hidden="true">0</span>
             <input
               type="range"
               min="0"
               max="100"
               step="1"
-              value={game.personal_rating || 0}
+              value={game.personal_rating ?? 0}
               onChange={(e) => onRatingChange?.(parseInt(e.target.value) || 0)}
               className="flex-1 h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer
                 [&::-webkit-slider-thumb]:appearance-none 
@@ -389,8 +402,9 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
                 [&::-moz-range-thumb]:rounded-full 
                 [&::-moz-range-thumb]:cursor-pointer
                 [&::-moz-range-thumb]:border-0"
+              aria-label={t('personalRating')}
             />
-            <span className="text-xs theme-text-muted">100</span>
+            <span className="text-xs theme-text-muted" aria-hidden="true">100</span>
           </div>
         </div>
 

--- a/src/components/Library/GameScreenshotsCarousel.tsx
+++ b/src/components/Library/GameScreenshotsCarousel.tsx
@@ -20,7 +20,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
   const [igdbScreenshots, setIgdbScreenshots] = useState<string[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [hasIgdbId, setHasIgdbId] = useState(false);
 
   useEffect(() => {
     const loadScreenshots = async () => {
@@ -29,7 +28,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
         // Load game data to check IGDB ID
         try {
           const game = await invoke<{ igdb_id: number | null }>("get_game_by_id", { id: gameId });
-          setHasIgdbId(!!game?.igdb_id);
           
           // Load IGDB screenshots if available
           if (game?.igdb_id) {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -342,6 +342,7 @@ export const translations = {
     manual: 'Manual',
     more: 'more',
     clearAll: 'Clear All',
+    clearRating: 'Clear Rating',
     tryAdjustingFilters: 'Try adjusting your filters',
     
     // Screenshot Background
@@ -728,6 +729,7 @@ export const translations = {
     manual: 'Manuel',
     more: 'de plus',
     clearAll: 'Tout effacer',
+    clearRating: 'Effacer la note',
     tryAdjustingFilters: 'Essayez d\'ajuster vos filtres',
     
     // Screenshot Background


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Added a "Clear Rating" button to the Personal Rating section in the game detail view, allowing users to unset their rating. Improved accessibility of the rating range input by adding proper ARIA labels and hiding decorative bound text from screen readers.

### 🎯 Why: The user problem it solves
Previously, once a user set a personal rating using the slider, there was no way to return it to an unset (null) state. This made it difficult to correct accidental ratings or simply remove one.

### ♿ Accessibility: Any a11y improvements made
- Added `aria-label` to the personal rating range input.
- Marked the "0" and "100" bound labels with `aria-hidden="true"` to prevent redundant announcements.
- The new "Clear Rating" button uses a semantic `<button>` with proper focus-visible styles and ARIA labels.

### 📸 Before/After: Screenshots if visual change
Visual verification completed with Playwright. The "Clear Rating" button appears next to the rating percentage when a rating is set.

---
*PR created automatically by Jules for task [10302715601205144344](https://jules.google.com/task/10302715601205144344) started by @Gamepulse*