### PR TITLE
🎨 Palette: Improve rating UX and card accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - [Accessibility & UX Polish]
+**Learning:** Replacing non-semantic interactive elements (like `<span>` with `role="button"`) with semantic `<button>` elements significantly improves keyboard accessibility and reduces custom logic. Additionally, providing a 'Clear' button for numeric range inputs allows users to reach a `null` state which is otherwise impossible with standard HTML range inputs.
+**Action:** Always prefer semantic `<button type="button">` for interactive elements and ensure all form controls have associated `<label>`s with `htmlFor`. Provide explicit 'Clear' actions for inputs where a "no value" state is semantically different from a "zero" value.

--- a/src/components/Library/GameCard.tsx
+++ b/src/components/Library/GameCard.tsx
@@ -31,24 +31,22 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
     return (
       <div className="flex flex-wrap gap-1 mt-2 pointer-events-auto">
         {displayedTags.map((tag) => (
-          <span
+          <button
             key={tag.id}
+            type="button"
             onClick={(e) => {
-              console.log('[GameCard] Click handler fired for tag:', tag.name);
               e.stopPropagation();
               e.preventDefault();
-              console.log('[GameCard] Calling onFilter with:', 'tag', tag.name);
               if (onFilter) {
                 onFilter('tag', tag.name);
-              } else {
-                console.warn('[GameCard] onFilter is undefined!');
               }
             }}
-            className={`relative z-20 px-2 py-0.5 text-xs rounded-full text-white ${getCategoryColor(tag.category)} hover:opacity-80 hover:scale-110 hover:shadow-md transition-all cursor-pointer select-none border border-transparent hover:border-white/30 pointer-events-auto`}
-            role="button"
+            className={`relative z-20 px-2 py-0.5 text-xs rounded-full text-white ${getCategoryColor(tag.category)} hover:opacity-80 hover:scale-110 hover:shadow-md transition-all cursor-pointer select-none border border-transparent hover:border-white/30 pointer-events-auto focus-visible:ring-2 focus-visible:ring-white outline-none`}
+            title={`${t('filterByTag')}: ${tag.name}`}
+            aria-label={`${t('filterByTag')}: ${tag.name}`}
           >
             {tag.name}
-          </span>
+          </button>
         ))}
         
         {remainingCount > 0 && (
@@ -73,19 +71,20 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
     return (
       <div className="flex flex-wrap gap-1 mt-1">
         {allMetadata.map((item) => (
-          <span
+          <button
             key={`${item.type}-${item.id}`}
+            type="button"
             onClick={(e) => {
               e.stopPropagation();
               e.preventDefault();
-              console.log('[GameCard] Metadata tag clicked:', item.type, item.name);
               onFilter?.(item.type, item.name);
             }}
-            className="px-1.5 py-0.5 text-xs rounded bg-gray-700/50 theme-text-muted hover:bg-indigo-600/30 transition-colors cursor-pointer select-none"
-            role="button"
+            className="px-1.5 py-0.5 text-xs rounded bg-gray-700/50 theme-text-muted hover:bg-indigo-600/30 transition-colors cursor-pointer select-none focus-visible:ring-1 focus-visible:ring-indigo-500 outline-none"
+            title={`${t('filterByTag')}: ${item.name}`}
+            aria-label={`${t('filterByTag')}: ${item.name}`}
           >
             {item.name}
-          </span>
+          </button>
         ))}
       </div>
     );
@@ -132,18 +131,19 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
     const label = COMPLETION_STATUS_LABELS[completion_status as keyof typeof COMPLETION_STATUS_LABELS] || completion_status;
     
     return (
-      <span
+      <button
+        type="button"
         onClick={(e) => {
           e.stopPropagation();
           e.preventDefault();
-          console.log('[GameCard] Status badge clicked:', completion_status);
           onFilter?.('status', completion_status);
         }}
-        className={`absolute top-2 left-2 px-2 py-1 rounded-full text-xs text-white ${statusColors[completion_status] || 'bg-gray-600'} hover:opacity-80 transition-opacity cursor-pointer select-none`}
-        role="button"
+        className={`absolute top-2 left-2 px-2 py-1 rounded-full text-xs text-white z-10 ${statusColors[completion_status] || 'bg-gray-600'} hover:opacity-80 transition-opacity cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-white outline-none`}
+        title={`${t('completionStatus')}: ${label}`}
+        aria-label={`${t('completionStatus')}: ${label}`}
       >
         {label}
-      </span>
+      </button>
     );
   };
 
@@ -264,6 +264,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
           {/* Status badge - small */}
           {completion_status && completion_status !== 'not_started' && (
             <button
+              type="button"
               onClick={(e) => {
                 e.stopPropagation();
                 onFilter?.('status', completion_status);
@@ -273,7 +274,9 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, viewMode, onFilter, 
                 completion_status === 'playing' ? 'bg-blue-600' :
                 completion_status === 'dropped' ? 'bg-red-600' :
                 completion_status === 'wishlist' ? 'bg-purple-600' : 'bg-gray-600'
-              } hover:opacity-80 transition-opacity cursor-pointer`}
+              } hover:opacity-80 transition-opacity cursor-pointer focus-visible:ring-1 focus-visible:ring-white outline-none`}
+              title={`${t('completionStatus')}: ${COMPLETION_STATUS_LABELS[completion_status as keyof typeof COMPLETION_STATUS_LABELS] || completion_status}`}
+              aria-label={`${t('completionStatus')}: ${COMPLETION_STATUS_LABELS[completion_status as keyof typeof COMPLETION_STATUS_LABELS] || completion_status}`}
             >
               {completion_status === 'not_started' ? 'Not Started' :
                completion_status === 'playing' ? 'Playing' :

--- a/src/components/Library/GameDetailHeader.tsx
+++ b/src/components/Library/GameDetailHeader.tsx
@@ -364,17 +364,31 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
         {/* Personal Rating */}
         <div className="space-y-2">
           <div className="flex items-center justify-between">
-            <span className="theme-text-muted text-sm">{t('personalRating')} (0-100): <span className="text-purple-500 font-semibold">{game.personal_rating !== null && game.personal_rating !== undefined ? `${game.personal_rating}/100` : '-'}</span></span>
+            <label htmlFor={`rating-${game.id}`} className="theme-text-muted text-sm cursor-pointer">
+              {t('personalRating')} (0-100): <span className="text-purple-500 font-semibold">{game.personal_rating !== null && game.personal_rating !== undefined ? `${game.personal_rating}/100` : '-'}</span>
+            </label>
+            {game.personal_rating !== null && game.personal_rating !== undefined && (
+              <button
+                type="button"
+                onClick={() => onRatingChange?.(null)}
+                className="text-xs text-red-400 hover:text-red-300 transition-colors flex items-center gap-1 px-1.5 py-0.5 rounded focus-visible:ring-2 focus-visible:ring-red-500 outline-none"
+                title={t('clearRating')}
+              >
+                <span aria-hidden="true">✕</span> {t('clearRating')}
+              </button>
+            )}
           </div>
           <div className="flex items-center gap-3">
-            <span className="text-xs theme-text-muted">0</span>
+            <span className="text-xs theme-text-muted" aria-hidden="true">0</span>
             <input
+              id={`rating-${game.id}`}
               type="range"
               min="0"
               max="100"
               step="1"
               value={game.personal_rating || 0}
               onChange={(e) => onRatingChange?.(parseInt(e.target.value) || 0)}
+              aria-label={`${t('personalRating')} (0-100)`}
               className="flex-1 h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer
                 [&::-webkit-slider-thumb]:appearance-none 
                 [&::-webkit-slider-thumb]:w-4 
@@ -390,7 +404,7 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
                 [&::-moz-range-thumb]:cursor-pointer
                 [&::-moz-range-thumb]:border-0"
             />
-            <span className="text-xs theme-text-muted">100</span>
+            <span className="text-xs theme-text-muted" aria-hidden="true">100</span>
           </div>
         </div>
 

--- a/src/components/Library/GameScreenshotsCarousel.tsx
+++ b/src/components/Library/GameScreenshotsCarousel.tsx
@@ -20,7 +20,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
   const [igdbScreenshots, setIgdbScreenshots] = useState<string[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [hasIgdbId, setHasIgdbId] = useState(false);
 
   useEffect(() => {
     const loadScreenshots = async () => {
@@ -29,7 +28,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
         // Load game data to check IGDB ID
         try {
           const game = await invoke<{ igdb_id: number | null }>("get_game_by_id", { id: gameId });
-          setHasIgdbId(!!game?.igdb_id);
           
           // Load IGDB screenshots if available
           if (game?.igdb_id) {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -46,6 +46,7 @@ export const translations = {
     name: 'Name',
     rating: 'Rating',
     dateAdded: 'Date Added',
+    clearRating: 'Clear Rating',
     
     // Game Detail
     personalRating: 'Personal Rating',
@@ -432,6 +433,7 @@ export const translations = {
     name: 'Nom',
     rating: 'Note',
     dateAdded: 'Date d\'ajout',
+    clearRating: 'Effacer la note',
     
     // Game Detail
     personalRating: 'Note personnelle',


### PR DESCRIPTION
### 💡 What: The UX enhancement added
- Added a "Clear Rating" button in the Game Detail view to allow users to unset their personal rating.
- Converted interactive tags and status badges in GameCard from `<span>` to semantic `<button>` elements.
- Improved accessibility by adding proper `<label>` associations, `aria-label`s, and `focus-visible` styles.
- Cleaned up an unused variable in `GameScreenshotsCarousel.tsx` to fix a build error.

### 🎯 Why: The user problem it solves
- Users previously had no way to remove a personal rating once set (only move it between 0-100).
- Keyboard users could not easily interact with tags or status badges on game cards as they weren't natively focusable.
- Screen reader users lacked context for what the interactive tags and badges did.

### ♿ Accessibility: Any a11y improvements made
- Replaced non-semantic `role="button"` with real buttons.
- Added high-contrast focus rings for keyboard navigation.
- Linked rating input to its label via `id`/`htmlFor`.
- Added descriptive `aria-label`s to interactive elements.
- Marked decorative icons with `aria-hidden="true"`.

---
*PR created automatically by Jules for task [14091871572349747328](https://jules.google.com/task/14091871572349747328) started by @Gamepulse*