### PR TITLE
🎨 Palette: Improve Personal Rating UX and Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2025-05-15 - [Clear Button for Numeric Inputs]
+**Learning:** Since native HTML range inputs cannot represent a `null` state, providing a separate 'Clear' or 'Remove' button allows users to unset numeric values like personal ratings, improving UX flexibility.
+**Action:** Always provide a 'Clear' action next to range inputs or sliders when the underlying data model supports an unassigned or null state.
+
+## 2025-05-15 - [Accessibility for Range Inputs]
+**Learning:** Visual labels representing the min/max bounds of a range input (e.g., '0' and '100' text) should be marked `aria-hidden="true"` to prevent redundant announcements by screen readers when the input itself is labeled.
+**Action:** Use `aria-hidden="true"` for decorative or redundant range bounds and ensure the input has a descriptive `aria-label`.

--- a/src/components/Library/GameDetailHeader.tsx
+++ b/src/components/Library/GameDetailHeader.tsx
@@ -364,10 +364,22 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
         {/* Personal Rating */}
         <div className="space-y-2">
           <div className="flex items-center justify-between">
-            <span className="theme-text-muted text-sm">{t('personalRating')} (0-100): <span className="text-purple-500 font-semibold">{game.personal_rating !== null && game.personal_rating !== undefined ? `${game.personal_rating}/100` : '-'}</span></span>
+            <span className="theme-text-muted text-sm">
+              {t('personalRating')} (0-100): <span className="text-purple-500 font-semibold">{game.personal_rating !== null && game.personal_rating !== undefined ? `${game.personal_rating}/100` : '-'}</span>
+            </span>
+            {game.personal_rating !== null && game.personal_rating !== undefined && (
+              <button
+                type="button"
+                onClick={() => onRatingChange?.(null)}
+                className="text-xs text-red-400 hover:text-red-300 transition-colors flex items-center gap-1 px-2 py-1 rounded hover:bg-red-900/20"
+                title={t('clearRating')}
+              >
+                ✕ {t('clearRating')}
+              </button>
+            )}
           </div>
           <div className="flex items-center gap-3">
-            <span className="text-xs theme-text-muted">0</span>
+            <span className="text-xs theme-text-muted" aria-hidden="true">0</span>
             <input
               type="range"
               min="0"
@@ -375,6 +387,7 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
               step="1"
               value={game.personal_rating || 0}
               onChange={(e) => onRatingChange?.(parseInt(e.target.value) || 0)}
+              aria-label={t('personalRating')}
               className="flex-1 h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer
                 [&::-webkit-slider-thumb]:appearance-none 
                 [&::-webkit-slider-thumb]:w-4 
@@ -390,7 +403,7 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
                 [&::-moz-range-thumb]:cursor-pointer
                 [&::-moz-range-thumb]:border-0"
             />
-            <span className="text-xs theme-text-muted">100</span>
+            <span className="text-xs theme-text-muted" aria-hidden="true">100</span>
           </div>
         </div>
 

--- a/src/components/Library/GameScreenshotsCarousel.tsx
+++ b/src/components/Library/GameScreenshotsCarousel.tsx
@@ -20,7 +20,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
   const [igdbScreenshots, setIgdbScreenshots] = useState<string[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [hasIgdbId, setHasIgdbId] = useState(false);
 
   useEffect(() => {
     const loadScreenshots = async () => {
@@ -29,7 +28,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
         // Load game data to check IGDB ID
         try {
           const game = await invoke<{ igdb_id: number | null }>("get_game_by_id", { id: gameId });
-          setHasIgdbId(!!game?.igdb_id);
           
           // Load IGDB screenshots if available
           if (game?.igdb_id) {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -342,6 +342,7 @@ export const translations = {
     manual: 'Manual',
     more: 'more',
     clearAll: 'Clear All',
+    clearRating: 'Clear Rating',
     tryAdjustingFilters: 'Try adjusting your filters',
     
     // Screenshot Background
@@ -728,6 +729,7 @@ export const translations = {
     manual: 'Manuel',
     more: 'de plus',
     clearAll: 'Tout effacer',
+    clearRating: 'Effacer la note',
     tryAdjustingFilters: 'Essayez d\'ajuster vos filtres',
     
     // Screenshot Background


### PR DESCRIPTION
💡 What: Added a "Clear Rating" button to the game detail header and improved the accessibility of the rating range input.

🎯 Why: Previously, once a personal rating was set using the slider, there was no way for the user to unset it (return to a null state). This improvement provides an intuitive way to clear the rating and ensures the input is accessible to screen readers.

♿ Accessibility:
- Added `aria-label` to the range input.
- Marked visual "0" and "100" labels as `aria-hidden="true"` to reduce screen reader noise.
- The new button includes a descriptive `title` and localized text.

🛠️ Fixes:
- Removed unused `hasIgdbId` state in `GameScreenshotsCarousel.tsx` which was causing `pnpm build` to fail during verification.

---
*PR created automatically by Jules for task [14481705926019518324](https://jules.google.com/task/14481705926019518324) started by @Gamepulse*