### PR TITLE
🎨 Palette: Improve Personal Rating UX and accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - [Clear Rating and Range Accessibility]
+**Learning:** HTML range inputs cannot naturally represent a `null` or "unset" state, which can be frustrating for users wanting to remove a rating. Additionally, range inputs require explicit ID-to-label associations and hiding of decorative bounds (like '0' and '100' text) to be fully accessible.
+**Action:** Always provide a 'Clear' button next to range inputs that handle nullable data, and ensure strict ARIA labeling with unique IDs for all form controls.

--- a/src/components/Library/GameDetailHeader.tsx
+++ b/src/components/Library/GameDetailHeader.tsx
@@ -364,11 +364,25 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
         {/* Personal Rating */}
         <div className="space-y-2">
           <div className="flex items-center justify-between">
-            <span className="theme-text-muted text-sm">{t('personalRating')} (0-100): <span className="text-purple-500 font-semibold">{game.personal_rating !== null && game.personal_rating !== undefined ? `${game.personal_rating}/100` : '-'}</span></span>
+            <label htmlFor={`rating-range-${game.id}`} className="theme-text-muted text-sm cursor-pointer">
+              {t('personalRating')} (0-100): <span className="text-purple-500 font-semibold">{game.personal_rating !== null && game.personal_rating !== undefined ? `${game.personal_rating}/100` : '-'}</span>
+            </label>
+            {game.personal_rating !== null && game.personal_rating !== undefined && (
+              <button
+                type="button"
+                onClick={() => onRatingChange?.(null)}
+                className="text-xs text-red-400 hover:text-red-300 transition-colors flex items-center gap-1"
+                aria-label={t('clearRating')}
+                title={t('clearRating')}
+              >
+                ✕ {t('clearRating')}
+              </button>
+            )}
           </div>
           <div className="flex items-center gap-3">
-            <span className="text-xs theme-text-muted">0</span>
+            <span className="text-xs theme-text-muted" aria-hidden="true">0</span>
             <input
+              id={`rating-range-${game.id}`}
               type="range"
               min="0"
               max="100"
@@ -390,7 +404,7 @@ export function GameDetailHeader({ game, onGameUpdated, onPlatformChange, onFilt
                 [&::-moz-range-thumb]:cursor-pointer
                 [&::-moz-range-thumb]:border-0"
             />
-            <span className="text-xs theme-text-muted">100</span>
+            <span className="text-xs theme-text-muted" aria-hidden="true">100</span>
           </div>
         </div>
 

--- a/src/components/Library/GameScreenshotsCarousel.tsx
+++ b/src/components/Library/GameScreenshotsCarousel.tsx
@@ -20,7 +20,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
   const [igdbScreenshots, setIgdbScreenshots] = useState<string[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [hasIgdbId, setHasIgdbId] = useState(false);
 
   useEffect(() => {
     const loadScreenshots = async () => {
@@ -29,7 +28,6 @@ export function GameScreenshotsCarousel({ gameId }: GameScreenshotsCarouselProps
         // Load game data to check IGDB ID
         try {
           const game = await invoke<{ igdb_id: number | null }>("get_game_by_id", { id: gameId });
-          setHasIgdbId(!!game?.igdb_id);
           
           // Load IGDB screenshots if available
           if (game?.igdb_id) {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -49,6 +49,7 @@ export const translations = {
     
     // Game Detail
     personalRating: 'Personal Rating',
+    clearRating: 'Clear Rating',
     notes: 'Notes',
     saveNotes: 'Save Notes',
     deleteGame: 'Delete Game',
@@ -435,6 +436,7 @@ export const translations = {
     
     // Game Detail
     personalRating: 'Note personnelle',
+    clearRating: 'Effacer la note',
     notes: 'Notes',
     saveNotes: 'Sauvegarder les notes',
     deleteGame: 'Supprimer le jeu',


### PR DESCRIPTION
This PR introduces several micro-UX and accessibility improvements to the Personal Rating section in the Game Detail view:

1.  **Clear Rating Functionality:** Since native HTML range inputs cannot represent a `null` state, users were previously unable to "unset" a rating once selected. I've added a "Clear Rating" button (✕ Effacer la note / Clear Rating) that appears when a rating is set, allowing users to reset it.
2.  **Accessibility (a11y) Improvements:**
    *   Properly associated the range input with its label using a unique ID (`rating-range-${game.id}`).
    *   Marked the visual bounds indicators ('0' and '100') as `aria-hidden="true"` to prevent redundant announcements by screen readers.
    *   Added `cursor-pointer` to the label for a better hit area.
3.  **Internationalization:** Added support for the new "Clear Rating" string in both English and French.
4.  **Build Fix:** Resolved a blocking TypeScript error in `GameScreenshotsCarousel.tsx` where the `hasIgdbId` state was declared but never used.

Verified visually with Playwright screenshots and passed `pnpm build` and `pnpm test`.

---
*PR created automatically by Jules for task [25789869176598812](https://jules.google.com/task/25789869176598812) started by @Gamepulse*